### PR TITLE
Fix common rtorrent xml-rpc crash when trying to queue an invalid task

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Donate to rTorrent development
  * Bitcoin: 1MpmXm5AHtdBoDaLZstJw8nupJJaeKu8V8
  * Etherium: 0x9AB1e3C3d8a875e870f161b3e9287Db0E6DAfF78
  * Litecoin: LdyaVR67LBnTf6mAT4QJnjSG2Zk67qxmfQ
- * Cardano: addr1q97wzvm8q4kc7dtmg782me2gkmmk3fewhsndt3le784wzdwa8kgkw4maafuxkv84q5pfcexakv9mpvr7hgj4kr53jy3q4n055m
+ * Cardano: addr1qytaslmqmk6dspltw06sp0zf83dh09u79j49ceh5y26zdcccgq4ph7nmx6kgmzeldauj43254ey97f3x4xw49d86aguqwfhlte
 
 
 Help keep rTorrent development going by donating to its creator.

--- a/src/rpc/command_scheduler_item.cc
+++ b/src/rpc/command_scheduler_item.cc
@@ -53,10 +53,14 @@ CommandSchedulerItem::enable(rak::timer t) {
 
   if (is_queued())
     disable();
+    
+  // Don't schedule invalid tasks for rpc commands
+  if (!m_task.is_valid())
+    return;
 
   // If 'first' is zero then we execute the task
   // immediately. ''interval()'' will not return zero so we never end
-  // up in an infinit loop.
+  // up in an infinite loop.
   m_timeScheduled = t;
   priority_queue_insert(&taskScheduler, &m_task, t);
 }


### PR DESCRIPTION
Instead of throwing an internal error and terminating the client, it's better not to queue the invalid task in the first place.